### PR TITLE
Managed identity authentication for azure keyvault

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ By default, FalconHound will look for the actions folder in the current director
 ```
 
 #### Run with credentials from a keyvault
-By default, FalconHound will use the credentials in the config.yml (or a custom loaded one). By setting the `-keyvault` flag FalconHound will get the keyvault from the config and retrieve all secrets from there. Should there be items missing in the keyvault it will fall back to the config file.
+By default, FalconHound will use the credentials in the config.yml (or a custom loaded one). By setting the `-keyvault` flag FalconHound will get the keyvault from the config and retrieve all secrets from there. Should there be items missing in the keyvault it will fall back to the config file. Should you wish to grab the secrets from an azure keyvault using a managed identity, define the authtype variable as msi. 
 
 ```bash
 ./falconhound -go -keyvault

--- a/cmd/getcreds.go
+++ b/cmd/getcreds.go
@@ -51,7 +51,7 @@ func GetCreds(configFile string, keyvaultFlag bool) (theCreds internal.Credentia
 		tag := field.Tag.Get("config")
 		var value string
 		if keyvaultFlag {
-			value, err = GetSecretFromAzureKeyVault(viper.GetString("keyvault.uri"), field.Name)
+			value, err = GetSecretFromAzureKeyVault(viper.GetString("keyvault.uri"), field.Name, viper.GetString("keyvault.authType"))
 			if err != nil {
 				LogInfo("[!] %s not in keyvault, grabbing it from the config...", field.Name)
 				value = viper.GetString(tag)

--- a/cmd/getkeyvaultsecrets.go
+++ b/cmd/getkeyvaultsecrets.go
@@ -5,14 +5,21 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets"
 	"github.com/spf13/viper"
 )
 
-func GetSecretFromAzureKeyVault(keyVaultName string, secretName string) (string, error) {
+func GetSecretFromAzureKeyVault(keyVaultName string, secretName string, authtype string) (string, error) {
 	// Create a new DefaultAzureCredential
-	cred, err := azidentity.NewClientSecretCredential(viper.GetString("keyvault.tenantID"), viper.GetString("keyvault.appID"), viper.GetString("keyvault.appSecret"), nil)
+	var cred azcore.TokenCredential
+	var err error
+	if authtype == "msi" {
+		cred, err = azidentity.NewManagedIdentityCredential(nil)
+	} else {
+		cred, err = azidentity.NewClientSecretCredential(viper.GetString("keyvault.tenantID"), viper.GetString("keyvault.appID"), viper.GetString("keyvault.appSecret"), nil)
+	}
 	// cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		log.Fatalf("Failed to create the credentials: %v", err)

--- a/config.yml-sample
+++ b/config.yml-sample
@@ -9,13 +9,15 @@
 # This is optional, when used, FalconHound will pull the
 # API keys from Keyvault instead of this file
 # start with the -keyvault flag
+# if authType is defined with MSI, then appID and appSecret can be omitted.
+# if you wish to use client secret credentials, then defined appid, tenantID and appSecret
 ################################################
 keyvault:
   uri: https://XXXXXXXX.vault.azure.net/
   tenantID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   appID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   appSecret: xxxxxxxxxxxxxx
-
+  authType: msi 
 ################################################
 # Add your Sentinel connection information here
 ################################################

--- a/config.yml-sample
+++ b/config.yml-sample
@@ -18,6 +18,7 @@ keyvault:
   appID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   appSecret: xxxxxxxxxxxxxx
   authType: msi 
+  
 ################################################
 # Add your Sentinel connection information here
 ################################################


### PR DESCRIPTION
This patch allows you to authenticate towards an azure keyvault to get required secrets to fetch all the necessary secrets (mde, bloodhound, neo4j, etc. It wont allow you to use a system assigned managed identity, but that can be implemented at a later stage. 

Do note, Im not a skilled developer by any means, these patches worked for me on getting the secrets without requiring a appid, secret and tenantid. 

