### PR TITLE
Update required_permissions + typo that broke Sentinel queries.md

### DIFF
--- a/actions/01-Sentinel/sen_get_aad_user_addedtogroup.yml
+++ b/actions/01-Sentinel/sen_get_aad_user_addedtogroup.yml
@@ -29,5 +29,5 @@ Targets:                                                   # Targets are the pla
     Parameters:
       ObjectId: ObjectId
       userPrincipalName: userPrincipalName
-      GroupObjectId: groupObjectId
+      groupObjectId: groupObjectId
       TimeGenerated: TimeGenerated

--- a/actions/01-Sentinel/sen_get_aad_user_removedfromgroup.yml
+++ b/actions/01-Sentinel/sen_get_aad_user_removedfromgroup.yml
@@ -28,4 +28,4 @@ Targets:                                                   # Targets are the pla
     Parameters:
       ObjectId: ObjectId
       userPrincipalName: userPrincipalName
-      GroupObjectId: groupObjectId
+      groupObjectId: groupObjectId

--- a/docs/required_permissions.md
+++ b/docs/required_permissions.md
@@ -114,13 +114,14 @@ To query the MS Graph API, you need to have the following Application API permis
 `Microsoft Graph => RoleEligibilitySchedule.Read.Directory`
 `Microsoft Graph => RoleManagement.Read.All`
 `Microsoft Graph => User.Read`
+`Microsoft Graph => Directory.Read.All`
 
 To add the required permissions for the MS Graph API to your Managed Identity, you can use the following script:
 ```powershell
 # Replace with your managed identity object ID
 $managedIdentityId = "<your managed identity app id>"
 $appId = "00000003-0000-0000-c000-000000000000"
-$permissionsToAdd = @("PrivilegedAccess.Read.AzureAD", "PrivilegedAccess.Read.AzureADGroup", "PrivilegedAccess.Read.AzureResources", "PrivilegedEligibilitySchedule.Read.AzureADGroup", "RoleAssignmentSchedule.Read.Directory", "RoleEligibilitySchedule.Read.Directory", "RoleManagement.Read.All","User.Read.All", "UserAuthenticationMethod.Read.All")
+$permissionsToAdd = @("PrivilegedAccess.Read.AzureAD", "PrivilegedAccess.Read.AzureADGroup", "PrivilegedAccess.Read.AzureResources", "PrivilegedEligibilitySchedule.Read.AzureADGroup", "RoleAssignmentSchedule.Read.Directory", "RoleEligibilitySchedule.Read.Directory", "RoleManagement.Read.All","User.Read.All", "UserAuthenticationMethod.Read.All", "Directory.Read.All")
 Connect-AzureAD
 $app = Get-AzureADServicePrincipal -Filter "AppId eq '$appId'"
 foreach ($permission in $permissionsToAdd)


### PR DESCRIPTION
Added Directory.Read.All as this is required for querying Dynamic Groups and OAuth consent via the Graph API.

Before / After:

![image](https://github.com/user-attachments/assets/83959479-0292-453f-baed-99b67d064cb9)

Also fixed typos that broke the Sentinel query for Users added to groups and removed from groups as it was waiting for the groupObjectId while the config declared it with uppercase GroupObjectId:

![image](https://github.com/user-attachments/assets/b20388f3-4fef-402f-8e88-626add23e15a)
